### PR TITLE
Fixes #19: Variable password strength bar

### DIFF
--- a/app/src/main/java/com/example/customviewdemoapplication/Views/ClockView.java
+++ b/app/src/main/java/com/example/customviewdemoapplication/Views/ClockView.java
@@ -1,0 +1,259 @@
+package com.example.customviewdemoapplication.Views;
+
+
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
+import android.util.AttributeSet;
+import android.util.Log;
+import android.view.View;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+
+import androidx.annotation.Nullable;
+
+public class ClockView extends View {
+
+    private Paint paint;
+    int hours;
+    int mins;
+    int secs;
+
+    int clockStroke;
+    Color clockColor;
+    int clockBackColor;
+    int clockStrokeColor;
+    private boolean stopClock;
+    private Paint textPaint;
+    private int clockTextColor;
+    private int textSize;
+    private Paint internPaint;
+
+
+    public ClockView(Context context, @Nullable AttributeSet attrs) {
+        super(context, attrs);
+        init(context,attrs);
+    }
+
+    public void setSystemTime(int hour, int minutes, int seconds){
+        this.hours=hour;
+        this.mins=minutes;
+        this.secs=seconds;
+        this.invalidate();
+    }
+
+    public void refreshTime(){
+        setSystemTime();
+        this.invalidate();
+    }
+
+    private void init(Context context,@Nullable AttributeSet attrs){
+        try {
+
+            this.setId(getId());
+            TypedArray a = context.getTheme().obtainStyledAttributes(attrs, R.styleable.clock_view, 0, 0);
+            try {
+                hours=a.getInteger(R.styleable.clock_view_hours,0);
+                mins=a.getInteger(R.styleable.clock_view_minutes,0);
+                secs=a.getInteger(R.styleable.clock_view_secs,0);
+                clockStroke=a.getDimensionPixelSize(R.styleable.clock_view_clockStroke,3);
+                textSize=a.getDimensionPixelSize(R.styleable.clock_view_textSize,10);
+                clockStrokeColor=a.getColor(R.styleable.clock_view_clockColor,Color.BLACK);
+                clockBackColor=a.getColor(R.styleable.clock_view_clockBackColor,Color.WHITE);
+                clockTextColor=a.getColor(R.styleable.clock_view_textColor,Color.GRAY);
+            } finally {
+                a.recycle();
+            }
+        }catch (Exception e){
+            Log.i("liunf",e.toString());
+        }
+
+        paint = new Paint();
+        paint.setStyle(Paint.Style.STROKE);
+        paint.setStrokeWidth(clockStroke);
+        paint.setColor(clockStrokeColor);
+
+        internPaint = new Paint();
+        internPaint.setStyle(Paint.Style.FILL);
+        internPaint.setStrokeWidth(clockStroke);
+        internPaint.setColor(clockBackColor);
+
+        textPaint=new Paint();
+        textPaint.setStyle(Paint.Style.STROKE);
+        textPaint.setColor(clockTextColor);
+        textPaint.setTextSize(textSize);
+
+        if( hours==0 ||mins==0||secs==0){
+            setSystemTime();
+        }
+    }
+
+
+    private void setSystemTime(){
+        Date d=Calendar.getInstance().getTime();
+        DateFormat df=new SimpleDateFormat("HH:mm:ss");
+        String[] timeArray=df.format(d).toString().split(":");
+
+        hours= Integer.parseInt(timeArray[0]);
+        mins= Integer.parseInt(timeArray[1]);
+        secs= Integer.parseInt(timeArray[2]);
+    }
+
+    @Override
+    protected void onDraw(Canvas canvas) {
+        super.onDraw(canvas);
+
+        float radius=0;
+        float viewWidth=getWidth();
+        float viewHeight=getHeight();
+        float cx=viewWidth/2;
+        float cy=viewHeight/2;
+        float minuteLen;
+        float hourLen;
+
+        if(viewWidth<viewHeight){
+            radius= (float) (0.9*viewWidth/2);
+        }else{
+            radius= (float) (0.9*viewHeight/2);
+        }
+        minuteLen= (float) (0.85*radius);
+        hourLen= (float) (0.5*radius);
+
+        canvas.drawCircle(cx,cy, (float) (radius),internPaint);
+        canvas.drawCircle(cx,cy,radius,paint);
+
+        float[] minutePoints=getMinutePoints(mins, (float) (minuteLen),cx,cy);
+        canvas.drawLine(cx,cy,minutePoints[0],minutePoints[1],paint);
+
+         float[] hourPoints=getHourPoints(hours%12,mins, (float) (hourLen),cx,cy);
+        canvas.drawLine(cx,cy,hourPoints[0],hourPoints[1],paint);
+
+        for(int hourNum=1, i=0;i<360;i+=30,hourNum++){
+            float[] numberPoints=getHourPoint(cx,cy, (float) (0.6*radius),i+30);
+            canvas.drawText(String.valueOf(hourNum),numberPoints[0],numberPoints[1],textPaint);
+        }
+    }
+
+
+    private float[] getHourPoint(float midX,float midY,float radius,float theta){
+
+        int quadrant=0;
+        if(theta<=90){
+            theta=90-theta;
+            quadrant=1;
+        }else if(theta>90 && theta<=180){
+            theta=theta-90;
+            quadrant=2;
+        }else if(theta>180 && theta<=270){
+            theta=270-theta;
+            quadrant=3;
+        }else if(theta>270 && theta<=360){
+            theta=theta-270;
+            quadrant=4;
+        }
+
+        float xValue= (float) (radius*Math.cos(Math.toRadians(theta)));
+        float yValue = (float) (radius  * Math.sin(Math.toRadians(theta)));
+        if(quadrant==1){
+            xValue+=midX;
+            yValue= (float) (midY-yValue);
+        }else if(quadrant==2){
+            xValue+=midX;
+            yValue= (float) (midY+yValue);
+        }else if(quadrant==3){
+            xValue=midX-xValue;
+            yValue= (float) (midY+yValue);
+        }else if(quadrant==4){
+            xValue=midX-xValue;
+            yValue= (float) (midY-yValue);
+        }
+        return new float[]{xValue,yValue};
+    }
+
+
+    private float[] getMinutePoints(int mins, float radius, float midX, double midY) {
+
+        float theta=mins*6;
+        int quadrant=1;
+        if(theta<=90){
+            theta=90-theta;
+            quadrant=1;
+        }else if(theta>90 && theta<=180){
+            theta=theta-90;
+            quadrant=2;
+        }else if(theta>180 && theta<=270){
+            theta=270-theta;
+            quadrant=3;
+        }else if(theta>270 && theta<=360){
+            theta=theta-270;
+            quadrant=4;
+        }
+
+        float xValue= (float) (radius*Math.cos(Math.toRadians(theta)));
+        float yValue = (float) (radius  * Math.sin(Math.toRadians(theta)));
+        if(quadrant==1){
+            xValue+=midX;
+            yValue= (float) (midY-yValue);
+        }else if(quadrant==2){
+            xValue+=midX;
+            yValue= (float) (midY+yValue);
+        }else if(quadrant==3){
+            xValue=midX-xValue;
+            yValue= (float) (midY+yValue);
+        }else if(quadrant==4){
+            xValue=midX-xValue;
+            yValue= (float) (midY-yValue);
+        }
+
+        return new float[]{xValue,yValue};
+    }
+
+    private double getLength(float x1, float y1, float x2, float y2){
+        return Math.sqrt(   (x2-x1)*(x2-x1)+(y2-y1)*(y2-y1));
+    }
+    private float[] getHourPoints(int hours,int mins, float radius, float midX, float midY) {
+
+        float theta=(hours*5+mins/12)*6;
+        int quadrant=1;
+        if(theta<=90){
+            theta=90-theta;
+            quadrant=1;
+        }else if(theta>90 && theta<=180){
+            theta=theta-90;
+            quadrant=2;
+        }else if(theta>180 && theta<=270){
+            theta=270-theta;
+            quadrant=3;
+        }else if(theta>270 && theta<=360){
+            theta=theta-270;
+            quadrant=4;
+        }
+
+        float xValue= (float) (radius*Math.cos(Math.toRadians(theta)));
+        float yValue = (float) (radius *  Math.sin(Math.toRadians(theta)));
+
+
+        if(quadrant==1){
+            xValue+=midX;
+            yValue= (float) (midY-yValue);
+        }else if(quadrant==2){
+            xValue+=midX;
+            yValue= (float) (midY+yValue);
+        }else if(quadrant==3){
+            xValue=midX-xValue;
+            yValue= (float) (midY+yValue);
+        }else if(quadrant==4){
+            xValue=midX-xValue;
+            yValue= (float) (midY-yValue);
+        }
+
+
+        return new float[]{xValue,yValue};
+    }
+
+}

--- a/app/src/main/java/com/example/customviewdemoapplication/Views/PasswordStrengthBar.java
+++ b/app/src/main/java/com/example/customviewdemoapplication/Views/PasswordStrengthBar.java
@@ -1,4 +1,4 @@
-package com.android.thenishchalraj.passwordstrength;
+package com.example.customviewdemoapplication;
 
 import android.annotation.SuppressLint;
 import android.content.Context;

--- a/app/src/main/java/com/example/customviewdemoapplication/Views/PasswordStrengthBar.java
+++ b/app/src/main/java/com/example/customviewdemoapplication/Views/PasswordStrengthBar.java
@@ -1,0 +1,356 @@
+package com.android.thenishchalraj.passwordstrength;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
+import android.graphics.RectF;
+import android.graphics.drawable.ColorDrawable;
+import android.graphics.drawable.Drawable;
+import android.graphics.drawable.LayerDrawable;
+import android.graphics.drawable.ScaleDrawable;
+import android.os.Build;
+import android.util.AttributeSet;
+import android.view.Gravity;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.LinearLayout;
+import android.widget.ProgressBar;
+
+/**
+ * Created by thenishchalraj on 10.10.2018.
+ */
+
+public class PasswordStrengthBar extends LinearLayout{
+
+    //UI
+    protected LinearLayout plb;
+    protected ProgressBar pb1;
+    protected ProgressBar pb2;
+    protected ProgressBar pb3;
+    protected ProgressBar pb4;
+
+    protected LayoutInflater mInflater;
+
+    //Attributes
+    private int mMax = 100;
+    private int mMin = 0;
+    private int mNoStrengthColor = Color.LTGRAY;
+    private int mStrengthColor1 = Color.RED;
+    private int mStrengthColor2 = Color.YELLOW;
+    private int mStrengthColor3 = Color.GREEN;
+    private int mStrengthColor4 = Color.DKGRAY;
+
+    //New Attributes by AJIRI GUNN
+    private int passBarsNum;
+    private boolean shouldUseCustomBars;
+    private int strength;
+    private int defaultBarColor;
+    private int[] strenthColorsArray;
+
+    public int getPassBarsNum() {
+        return passBarsNum;
+    }
+
+    private void setPassBarsNum(int passBarsNum) {
+        this.passBarsNum = passBarsNum;
+        shouldUseCustomBars =true;
+    }
+
+    private void setupStrengthColors(int passBars) {
+        int r=255;
+        int g=0;
+        int b=0;
+        strenthColorsArray =new int[passBars];
+        double colorDiff=Math.floor(250/(Math.ceil(passBars/2)));//differences between colors
+
+        //START with RED. Increase GREEN component till mid-bar.REDUCE RED component.
+        for(int i=0;i<passBars;i++){
+            int newColor=Color.rgb(r,g,b);
+            strenthColorsArray[i]=newColor;
+            if(i>=Math.floor(passBars/2)) {//
+                r -= colorDiff;
+            }else{
+                g+=colorDiff;
+            }
+        }
+    }
+
+//
+    public PasswordStrengthBar(Context context) {
+        super(context,null);
+        init(context, null);
+    }
+
+    public PasswordStrengthBar(Context context, AttributeSet attrs) {
+        super(context, attrs,0);
+        init(context,attrs);
+    }
+
+    public PasswordStrengthBar(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        init(context, attrs);
+    }
+
+    /**initiate views*/
+    protected void init(Context context, AttributeSet attrs){
+        mInflater = LayoutInflater.from(context);
+
+        TypedArray a = context.getTheme().obtainStyledAttributes(attrs, R.styleable.password_strength, 0, 0);
+        try {
+            mMax=a.getInteger(R.styleable.password_strength_maxProgress,0);
+            mMin=a.getInteger(R.styleable.password_strength_minProgress,0);
+            passBarsNum =a.getInteger(R.styleable.password_strength_bars,0);
+            strength=a.getInteger(R.styleable.password_strength_strength,0);
+            defaultBarColor =a.getColor(R.styleable.password_strength_defColor,Color.GRAY);
+        } finally {
+            a.recycle();
+        }
+
+        if(passBarsNum ==0){
+            setDefaultViews();
+        }else {
+            setCustomBarViews();
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            setMinStrength(mMin);
+            setMaxStrength(mMax);
+        }
+    }
+
+    private void setCustomBarViews(){
+        shouldUseCustomBars =true;
+        setupStrengthColors(passBarsNum);
+        defaultBarColor = Color.DKGRAY;
+        this.invalidate();
+    }
+
+    private void setDefaultViews(){
+        //        load view from xml
+        shouldUseCustomBars =false;
+        View view = mInflater.inflate(R.layout.password_strength_bar,this,true);
+        //init UI
+        plb = view.findViewById(R.id.progressLinearBar);
+        pb1 = view.findViewById(R.id.pBar1);
+        pb2 = view.findViewById(R.id.pBar2);
+        pb3 = view.findViewById(R.id.pBar3);
+        pb4 = view.findViewById(R.id.pBar4);
+        setMaxStrength(mMax);
+        setMinStrength(mMin);
+        setStrength(strength);
+    }
+
+    @Override
+    protected void onDraw(Canvas canvas) {
+        super.onDraw(canvas);
+
+        if(!shouldUseCustomBars){
+            return;
+        }
+        float width=getWidth();
+        float height=getHeight();
+        float rectRadius=getHeight()/2;
+        float percentPerBar=mMax/ passBarsNum;
+
+        float barWidth=((100-0.01f* passBarsNum)*width)/(100* passBarsNum);
+        float left= (float) (0.001*width);
+        float top= (float) (height*0.01);
+        float bottom=(float) (height*0.99);
+        float right=left+barWidth;
+
+        for(int i = 1; i<= passBarsNum; i++){
+
+            if (i*percentPerBar<=strength || i*percentPerBar<=mMin) {
+                //Draw a fully colored curved bar
+                drawCurvedBar(canvas,left,top,right,bottom,rectRadius,strenthColorsArray[i-1]);
+
+            } else if(i*percentPerBar>=strength &&(i-1)*percentPerBar<strength ) {
+
+                float percentProgress=(strength-(i-1)*percentPerBar)/100;
+                float tempRight=percentProgress*barWidth+left;
+                //Draw colored part of progressBar
+                drawBar(canvas,left,top,tempRight,bottom,strenthColorsArray[i-1]);
+                //Draw neutral part of progressBar
+                drawBar(canvas,tempRight,top,right,bottom,defaultBarColor);
+            }else{
+                //Draw a neutral colored curved bar
+                drawCurvedBar(canvas,left,top,right,bottom,rectRadius,defaultBarColor);
+            }
+            left= (float) (right+(0.001*width));
+            right=left+barWidth;
+        }
+    }
+
+    private void drawCurvedBar(Canvas canvas, float left, float top, float right, float bottom, float radius, int color){
+        Paint p=new Paint();
+        p.setStyle(Paint.Style.FILL);
+        p.setColor(color);
+        RectF f=new RectF(left,top,right,bottom);
+        canvas.drawRoundRect(f,radius,radius,p);
+    }
+
+    private void drawBar(Canvas canvas, float left, float top, float right, float bottom,  int color){
+        Paint p=new Paint();
+        p.setStyle(Paint.Style.FILL);
+        p.setColor(color);
+        RectF f=new RectF(left,top,right,bottom);
+        canvas.drawRect(f,p);
+    }
+    /**
+     * Implement the below method to set the password strength to default chosen color
+     */
+    public void setStrengthColor(int noStrengthColor, int color1, int color2, int color3, int color4){
+
+        this.mNoStrengthColor = noStrengthColor;
+        this.mStrengthColor1 = color1;
+        this.mStrengthColor2 = color2;
+        this.mStrengthColor3 = color3;
+        this.mStrengthColor4 = color4;
+
+        Drawable backgroundDr = new ColorDrawable(noStrengthColor);
+
+        //color layers for password bar 1
+        Drawable progressDr1 = new ScaleDrawable(new ColorDrawable(color1), Gravity.LEFT, 1, -1);
+        LayerDrawable resultDr1 = new LayerDrawable(new Drawable[] { backgroundDr, progressDr1 });
+        pb1.setProgressDrawable(resultDr1);
+
+        //color layers for password bar 2
+        Drawable progressDr2 = new ScaleDrawable(new ColorDrawable(color2), Gravity.LEFT, 1, -1);
+        LayerDrawable resultDr2 = new LayerDrawable(new Drawable[] { backgroundDr, progressDr2 });
+        pb2.setProgressDrawable(resultDr2);
+
+        //color layers for password bar 3
+        Drawable progressDr3 = new ScaleDrawable(new ColorDrawable(color3), Gravity.LEFT, 1, -1);
+        LayerDrawable resultDr3 = new LayerDrawable(new Drawable[] { backgroundDr, progressDr3 });
+        pb3.setProgressDrawable(resultDr3);
+
+        //color layers for password bar 4
+        Drawable progressDr4 = new ScaleDrawable(new ColorDrawable(color4), Gravity.LEFT, 1, -1);
+        LayerDrawable resultDr4 = new LayerDrawable(new Drawable[] { backgroundDr, progressDr4 });
+        pb4.setProgressDrawable(resultDr4);
+
+    }
+
+
+    /**
+     * Implement the below two methods to get the maximum
+     * and minimum value to which the password strength can be calculated
+     */
+    public int getMaxStrength(){
+        return mMax;
+    }
+    public int getMinStrength(){
+        return mMin;
+    }
+
+
+    /**
+     * implement the below two methods to set the maximum
+     * and minimum value to which the password strength can
+     * be calculated
+     */
+    public void setMaxStrength(int max) {
+        this.mMax = max;
+        if (!shouldUseCustomBars) {
+            max /= 4;
+            pb1.setMax(max);
+            pb2.setMax(max);
+            pb3.setMax(max);
+            pb4.setMax(max);
+        }
+    }
+
+    @SuppressLint("NewApi")
+//    @RequiresApi(api = Build.VERSION_CODES.O)
+    public void setMinStrength(int min) {
+        this.mMin = min;
+        if (!shouldUseCustomBars) {
+            min /= 4;
+            pb1.setMin(min);
+            pb2.setMin(min);
+            pb3.setMin(min);
+            pb4.setMin(min);
+        }
+    }
+
+
+    /**
+     * implement the below method to get the strength of the bar
+     */
+    public int getStrength(){
+        if(!shouldUseCustomBars)//IF new implementation isn't in effect
+            return pb1.getProgress()+pb2.getProgress()+pb3.getProgress()+pb4.getProgress() ;
+        else
+            return strength;
+    }
+
+
+    /**
+     * Don't want complex ways to set the strength then use simple calculations
+     * Below method to set the strength of the bar
+     */
+    public void setStrength(int strength){
+        this.strength=strength;
+
+        if(shouldUseCustomBars){
+            this.invalidate();
+            return;
+        }
+
+        if(strength <= mMin){
+            //set all the progress bar to its minimum value
+            pb1.setProgress(mMin/4);
+            pb2.setProgress(mMin/4);
+            pb3.setProgress(mMin/4);
+            pb4.setProgress(mMin/4);
+        }
+        else if(strength >= mMax){
+            //set all the progress bar to its maximum value
+            pb1.setProgress(mMax/4);
+            pb2.setProgress(mMax/4);
+            pb3.setProgress(mMax/4);
+            pb4.setProgress(mMax/4);
+        }
+        else{
+            //set the progress bar accordingly
+            if(strength-mMax/4 >= mMin/4 ){
+                pb1.setProgress(mMax/4);
+                pb2.setProgress(mMin);
+                pb3.setProgress(mMin);
+                pb4.setProgress(mMin);
+                strength -= (mMax/4);
+                if(strength-mMax/4 >= mMin/4 ){
+                    pb2.setProgress(mMax/4);
+                    pb3.setProgress(mMin);
+                    pb4.setProgress(mMin);
+                    strength -= (mMax/4);
+                    if(strength-mMax/4 >= mMin/4 ){
+                        pb3.setProgress(mMax/4);
+                        pb4.setProgress(mMin);
+                        strength -= (mMax/4);
+                        if(strength-mMax/4 >= mMin/4 ){
+                            pb4.setProgress(mMax/4);
+                        }else{
+                            pb4.setProgress(strength);
+                        }
+                    }else{
+                        pb3.setProgress(strength);
+                        pb4.setProgress(mMin);
+                    }
+                }else{
+                    pb2.setProgress(strength);
+                    pb3.setProgress(mMin);
+                    pb4.setProgress(mMin);
+                }
+            }else{
+                pb1.setProgress(strength);
+                pb2.setProgress(mMin);
+                pb3.setProgress(mMin);
+                pb4.setProgress(mMin);
+            }
+        }
+    }
+}

--- a/app/src/main/res/layout/password_strength_bar.xml
+++ b/app/src/main/res/layout/password_strength_bar.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical" android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:id="@+id/progressLinearBar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="2dp"
+        android:orientation="horizontal">
+
+        <ProgressBar
+            android:id="@+id/pBar1"
+            style="@android:style/Widget.ProgressBar.Horizontal"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="2dp"
+            android:layout_marginEnd="2dp"
+            android:layout_weight="1"/>
+
+        <ProgressBar
+            android:id="@+id/pBar2"
+            style="@android:style/Widget.ProgressBar.Horizontal"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="2dp"
+            android:layout_weight="1"
+            android:layout_marginRight="2dp" />
+
+        <ProgressBar
+            android:id="@+id/pBar3"
+            style="@android:style/Widget.ProgressBar.Horizontal"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="2dp"
+            android:layout_weight="1"
+            android:layout_marginRight="2dp" />
+
+        <ProgressBar
+            android:id="@+id/pBar4"
+            style="@android:style/Widget.ProgressBar.Horizontal"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="2dp"
+            android:layout_weight="1"
+            android:layout_marginRight="2dp" />
+
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -4,6 +4,17 @@
     <attr name="strokeWidth" format="dimension"/>
     <attr name="strokeColor" format="color"/>
     <attr name="textColor" format="color"/>
+    
+    
+    <declare-styleable name="password_strength">
+        <attr name="maxProgress" format="integer"/>
+        <attr name="minProgress" format="integer"/>
+        <attr name="bars" format="integer"/>
+        <attr name="strength" format="integer"/>
+        <attr name="defColor" format="color"/>
+
+    </declare-styleable>
+
 
      <declare-styleable name="clock_view">
         <attr name="useSystemTime" format="boolean"/>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -5,6 +5,19 @@
     <attr name="strokeColor" format="color"/>
     <attr name="textColor" format="color"/>
 
+     <declare-styleable name="clock_view">
+        <attr name="useSystemTime" format="boolean"/>
+        <attr name="hours" format="integer"/>
+        <attr name="minutes" format="integer"/>
+        <attr name="secs" format="integer"/>
+        <attr name="clockStroke" format="dimension"/>
+        <attr name="textSize" format="dimension"/>
+        <attr name="clockColor" format="color" />
+        <attr name="textColor" format="color" />
+        <attr name="clockBackColor" format="color"/>
+
+    </declare-styleable>
+    
     <declare-styleable name="MyView">
         <attr name="square_color" format="color"/>
         <attr name="square_size" format="dimension"/>


### PR DESCRIPTION
This patch allows developer to specify a variable number of progressbars and automatically sets the 
range of colors from RED:weakest to GREEN:strongest.
The bars attribute would have to be set in xml; failure to specify this attribute would automatically inflate the 
layout with four progressbars allowing user to specify colors, maximum and minimum as before.

other attributes can also be set in xml:
 name="maxProgress" format="integer"
 name="minProgress" format="integer"
 name="bars" format="integer"
 name="strength" format="integer"
 name="defColor" format="color"

sample:

    <com.android.thenishchalraj.PasswordStrengthBar
            android:layout_width="match_parent"
            android:layout_height="8dp"
            android:id="@+id/passStrength"
            android:background="@android:color/transparent"
            android:layout_gravity="center"
	    app:bars="5"
            app:minProgress="10"
            app:maxProgress="400"
            app:strength="330"/>

NOTE: The variable bars functionality can only be triggered if set from xml not programmatically. The "setStrength(int strength)" method can still be used programmatically.
![Screenshot_20201005-211110](https://user-images.githubusercontent.com/37802577/95216049-8e3bf300-07e9-11eb-9ea5-1348dc5251d9.png)

Fixes #19 
